### PR TITLE
Feature/distribution interface

### DIFF
--- a/src/skg_manager/validation_and_calibration/ecdf_services/ecdf_execution_times_between_sensors_handler.py
+++ b/src/skg_manager/validation_and_calibration/ecdf_services/ecdf_execution_times_between_sensors_handler.py
@@ -38,7 +38,7 @@ class ExecutionTimesBetweenSensorsEcdfHandler(EcdfServiceInterface):
             times as dist_values
             '''
         return Query(query_str=query_str,
-                     template_string_parameters={
+                     parameters={
                          "start_time": start_time,
                          "end_time": end_time
                      })

--- a/src/skg_manager/validation_and_calibration/ecdf_services/ecdf_execution_times_between_sensors_handler.py
+++ b/src/skg_manager/validation_and_calibration/ecdf_services/ecdf_execution_times_between_sensors_handler.py
@@ -5,17 +5,17 @@ from skg_manager.validation_and_calibration.vc_service_interfaces.ecdf_service_i
 
 class ExecutionTimesBetweenSensorsEcdfHandler(EcdfServiceInterface):
     def __init__(self, db_connection):
-        super().__init__(db_connection, type="Execution Times Between Sensors")
+        super().__init__(db_connection, described_behavior="Execution Times Between Sensors")
 
     def extract_ecdf_query_function(self, start_time="1970-01-01 00:00:00", end_time="2970-01-01 23:59:59"):
         """
         Provide a Query object that finds a list of numerical values (samples) for which an ecdf can be created.
         The query should return the following information
-        - element_id --> the ecdf describes the distribution of an object, the element_id is id of the object in the skg
         - key --> the ecdf describes the distribution of an object, the key is a unique description of this object
         which can be understood by humans
+        - element_id --> the ecdf describes the distribution of an object, the element_id is id of the object in the skg
         - is_simulated_data --> the ecdf is retrieved for simulated data or ground truth data
-        - entity_type --> the entity_type
+        - entity_type --> the entity_type for which the distribution is calculated
         - dist_values --> the values of the ecdf (a list of numerical values)
 
         :param start_time: start time of interval formatted as "yyyy-MM-dd HH:mm:ss"

--- a/src/skg_manager/validation_and_calibration/vc_service_interfaces/ecdf_service_interface.py
+++ b/src/skg_manager/validation_and_calibration/vc_service_interfaces/ecdf_service_interface.py
@@ -7,9 +7,9 @@ from skg_manager.generic.queries.performance_queries import PerformanceQueryLibr
 
 class EcdfServiceInterface(ABC):
 
-    def __init__(self, db_connection, type):
+    def __init__(self, db_connection, described_behavior):
         self.db_connection = db_connection
-        self._type = type
+        self._described_behavior = described_behavior
 
     @staticmethod
     def check_is_date(timestamp):
@@ -62,14 +62,14 @@ class EcdfServiceInterface(ABC):
 
     def remove_ecdf_nodes_from_skg(self):
         self.db_connection.exec_query(pfql.delete_ecdf_nodes,
-                                      **{"_type": self._type})
+                                      **{"_type": self._described_behavior})
 
     def retrieve_ecdf_nodes_from_skg(self):
         return self.db_connection.exec_query(pfql.retrieve_distributions,
-                                             **{"_type": self._type})
+                                             **{"_type": self._described_behavior})
 
-    def get_type(self):
-        return self._type
+    def get_described_behavior(self):
+        return self._described_behavior
 
     @abstractmethod
     def extract_ecdf_query_function(self, start_time="1970-01-01 00:00:00", end_time="2970-01-01 23:59:59") -> Query:

--- a/src/skg_manager/validation_and_calibration/vc_service_interfaces/ecdf_service_interface.py
+++ b/src/skg_manager/validation_and_calibration/vc_service_interfaces/ecdf_service_interface.py
@@ -74,13 +74,13 @@ class EcdfServiceInterface(ABC):
     @abstractmethod
     def extract_ecdf_query_function(self, start_time="1970-01-01 00:00:00", end_time="2970-01-01 23:59:59") -> Query:
         """
-        Provide a Query object that finds a list of numerical values (samples) for which a an ecdf can be created.
+        Provide a Query object that finds a list of numerical values (samples) for which an ecdf can be created.
         The query should return the following information
-        - element_id --> the ecdf describes the distribution of an object, the element_id is id of the object in the skg
         - key --> the ecdf describes the distribution of an object, the key is a unique description of this object
         which can be understood by humans
+        - element_id --> the ecdf describes the distribution of an object, the element_id is id of the object in the skg
         - is_simulated_data --> the ecdf is retrieved for simulated data or ground truth data
-        - entity_type --> the entity_type
+        - entity_type --> the entity_type for which the distribution is calculated
         - dist_values --> the values of the ecdf (a list of numerical values)
 
         :param start_time: start time of interval formatted as "yyyy-MM-dd HH:mm:ss"

--- a/src/skg_manager/validation_and_calibration/vc_services/ecdf_wrapper_service.py
+++ b/src/skg_manager/validation_and_calibration/vc_services/ecdf_wrapper_service.py
@@ -9,7 +9,7 @@ class EcdfWrapper(EcdfWrapperInterface):
                  ecdf_handler: EcdfServiceInterface):
 
         self.ecdf_handler = ecdf_handler
-        self._type = self.ecdf_handler.get_type()
+        self._described_behavior = self.ecdf_handler.get_described_behavior()
 
         self.metric_measures = metric_measures
 
@@ -26,7 +26,7 @@ class EcdfWrapper(EcdfWrapperInterface):
         try:
             results = self.ecdf_handler.extract_ecdfs_from_skg(start_time=start_time, end_time=end_time)
             logging.debug(
-                f"Distribution {self.ecdf_handler.get_type()} fetched for "
+                f"Distribution {self._described_behavior} fetched for "
                 f"{start_time if start_time is not None else ''} - {end_time if end_time is not None else ''} : "
                 f"{results}")
 
@@ -35,7 +35,6 @@ class EcdfWrapper(EcdfWrapperInterface):
                 return None  # Early return if no data is found
 
             for skg_result in results:
-                print(skg_result)
                 distribution = self.create_annotated_ecdf(skg_result)
                 self.add_ecdf_to_pairings(distribution)
 
@@ -52,11 +51,11 @@ class EcdfWrapper(EcdfWrapperInterface):
 
         # Create ECDF object
         distribution = AnnotatedECDF(values=dist_values,
-                                     legend=f"{self._type}: {key}",
+                                     legend=f"{self._described_behavior}: {key}",
                                      key=key,
                                      entity_type=entity_type,
                                      element_id=element_id,
-                                     _type=self._type,
+                                     _type=self._described_behavior,
                                      gt_sim=gt_sim)
         return distribution
 
@@ -100,10 +99,10 @@ class EcdfWrapper(EcdfWrapperInterface):
 
     def create_index_file(self):
         f = open(self.working_dir + "/index.html", "w")
-        f.write(f"<h2>Ecdf for {self._type}</h2>\n")
+        f.write(f"<h2>Ecdf for {self._described_behavior}</h2>\n")
         for index, ecdf_pairing in enumerate(self.distribution_pairings.values()):
             ecdf_pairing.plot_to_file(self.working_dir, show=False)
-            f.write("<h4>" + self._type + ": " + ecdf_pairing.return_title() + "\n")
+            f.write("<h4>" + self._described_behavior + ": " + ecdf_pairing.return_title() + "\n")
             f.write(
                 f"<a id='eCDF {index}'></h4><img src='{ecdf_pairing.return_title()}.svg'><a href='#top'>back to "
                 f"top<a><br>\n")


### PR DESCRIPTION
# Pull Request Summary

**Closes**:  
- #10  
- #11  
- #12  
- #13  

## Description

This PR introduces interfaces for:  
1. Calculating cumulative distribution functions (CDFs).  
2. Computing metrics that compare ground truth CDFs with simulation CDFs.  

## Features
### CDF Interface  

The end user can define a query that retrieves relevant data from the SKG to create empirical cumulative distribution functions (ECDFs).  

An ECDF illustrates the distribution of a specific behavior (e.g., execution times between sensors) at a defined location (e.g., the connection object between two sensors) for specific entities (entity type).  

To implement this functionality, the user must provide a class that adheres to the `EcdfServiceInterface`. This class should include:  
1. An `__init__` method to define the described behavior.  
2. The `extract_ecdf_query_function` method to specify the query logic.  

The query must supply the following:  
- `element_id`: ID of the object in the SKG that the ECDF represents.  
- `key`: A human-readable identifier for the object.  
- `is_simulated_data`: Indicates whether the ECDF pertains to simulated or ground truth data.  
- `entity_type`: The entity type described by the ECDF.  
- `dist_values`: A list of numerical values for constructing the ECDF.  

**Query parameters**:  
- `start_time`: Start of the time interval (`"yyyy-MM-dd HH:mm:ss"`).  
- `end_time`: End of the time interval (`"yyyy-MM-dd HH:mm:ss"`).  
The query should return a list of numerical values satisfying the above criteria.  

#### Example Implementation

```python
class ExecutionTimesBetweenSensorsEcdfHandler(EcdfServiceInterface):
    def __init__(self, db_connection):
        super().__init__(db_connection, described_behavior="Execution Times Between Sensors")

    def extract_ecdf_query_function(self, start_time="1970-01-01 00:00:00", end_time="2970-01-01 23:59:59"):
        """
        Provides a Query object to retrieve numerical values (samples) for generating an ECDF.
        The query returns:
        - element_id: ID of the object in the SKG that the ECDF describes.
        - key: A unique, human-readable identifier for the object.
        - is_simulated_data: Indicates if the ECDF is for simulated or ground truth data.
        - entity_type: The entity type for which the ECDF is calculated.
        - dist_values: A list of numerical values used to create the ECDF.

        :param start_time: Start time of the interval, formatted as "yyyy-MM-dd HH:mm:ss".
        :param end_time: End time of the interval, formatted as "yyyy-MM-dd HH:mm:ss".
        :return: A Query object that retrieves the required numerical values.
        """
        query_str = '''
            MATCH (e1:Event) - [r:DF_CONTROL_FLOW_ITEM] -> (e2)
            WHERE e1.timestamp >= datetime(apoc.date.convertFormat($start_time,"yyyy-MM-dd HH:mm:ss","ISO_DATE_TIME")) 
              AND e2.timestamp <= datetime(apoc.date.convertFormat($end_time,"yyyy-MM-dd HH:mm:ss","ISO_DATE_TIME")) 
            MATCH (e1) - [:ACTS_ON] -> (k) - [:IS_OF_TYPE] -> (et)
            MATCH (e1)-[:EXECUTED_BY]->(s1:Sensor)
            MATCH (e2)-[:EXECUTED_BY]->(s2:Sensor)
            MATCH (s1)-->(connection:Connection)-->(s2)
            WITH elementId(connection) AS element_id, 
                 s1.simulated IS NOT NULL AS is_simulated_data, 
                 s1.sysId AS input_sensor, 
                 s2.sysId AS output_sensor, 
                 et.entityType AS entity_type, 
                 COLLECT(duration.inSeconds(e1.timestamp, e2.timestamp).seconds) AS times
            RETURN element_id, 
                   entity_type, 
                   is_simulated_data, 
                   input_sensor + "-" + output_sensor + "-" + entity_type AS key, 
                   times AS dist_values
        '''
        return Query(query_str=query_str,
                     parameters={
                         "start_time": start_time,
                         "end_time": end_time
                     })
```

### Metrics Interface  
To compute metrics, the Metric Interface requires implementing the `calculate` method, which compares ground truth distributions with simulation distributions, `get_name` method, which gives the name of the metric, and the `get_optimization_direction`, which specifies whether the metric should be minimized or maximized.

### ECDF Wrapper  
The `EcdfWrapper` streamlines the workflow by:  
1. Fetching all required distributions.  
2. Pairing ground truth distributions with their corresponding simulation distributions.  
3. Computing specified metrics for each distribution pair.  
4. Generating an index file to visualize results.  

## Usage Example

An end-user can define their distributions and metrics and register the performance router as follows:  

```python
from skg_manager.api.router.generic_routers.performance_router import PerformanceRouter
from skg_manager.validation_and_calibration import EcdfWrapper
from skg_manager.validation_and_calibration.ecdf_services import ExecutionTimesBetweenSensorsEcdfHandler
from skg_manager.validation_and_calibration.metrics import KolmogorovMetric, MedianRatioMetric, SimilarityMetric, \
    WassersteinDistanceMetric

distributions_with_metrics = [
    {
        "ecdf_handler": ExecutionTimesBetweenSensorsEcdfHandler(db_connection=db_connection),
        "metric_measures": [KolmogorovMetric(), MedianRatioMetric(), SimilarityMetric(),
                            WassersteinDistanceMetric()]
    }
]

ecdf_wrappers = [EcdfWrapper(
    metric_measures=distribution_with_metrics["metric_measures"],
    ecdf_handler=distribution_with_metrics["ecdf_handler"],
    working_dir="performance_results") for distribution_with_metrics in distributions_with_metrics]

app.register_performance_router(
    performance_router=PerformanceRouter(ecdf_wrappers=ecdf_wrappers))
